### PR TITLE
Fix page focus flicker

### DIFF
--- a/app/javascript/components/App.js
+++ b/app/javascript/components/App.js
@@ -1,6 +1,5 @@
 import React from "react"
 import styled from "styled-components"
-import moment from "moment"
 
 import Application from "./assemble/Application"
 import SlideFromBottom from "./assemble/transitions/SlideFromBottom"
@@ -33,24 +32,13 @@ class App extends React.Component {
   }
 
   componentDidMount() {
-    this.setTime()
-    this.timer = setInterval(() => this.setTime(), 1000)
-
     this.fetchState()
-  }
-
-  componentWillUnmount() {
-    clearInterval(this.timer)
   }
 
   fetchState() {
     fetch("/state").then((response) => response.json()).then((app_state) => {
       this.setState({ loaded: true, app: app_state })
     });
-  }
-
-  setTime() {
-    this.setState({ current_time: moment() })
   }
 
   render () {
@@ -60,7 +48,6 @@ class App extends React.Component {
 
         { this.state.loaded
           ? <Lobby
-              current_time={this.state.current_time}
               position={layoutLeft}
               services={this.state.app.services}
               refresh={this.fetchState.bind(this)}
@@ -76,7 +63,6 @@ class App extends React.Component {
                 {...params}
                 state={this.state.app}
                 refresh={this.fetchState.bind(this)}
-                current_time={this.state.current_time}
               />
             }
             position={layoutRight}

--- a/app/javascript/components/Lobby.js
+++ b/app/javascript/components/Lobby.js
@@ -1,5 +1,6 @@
 import React from "react"
 import styled from "styled-components"
+import moment from "moment"
 
 import Table from "./Table"
 
@@ -9,27 +10,51 @@ const service_directory = {
   ktv: "🎤 ",
 }
 
-const Lobby = (props) => (
-  <Layout position={props.position}>
-    { Object.keys(service_directory).map((service_name) => (
-      <Service key={service_name}>
-        <Emoji>{ service_directory[service_name] }</Emoji>
+class Lobby extends React.Component {
+  constructor(props) {
+    super(props)
 
-        <Tables>
-          {props.services.filter(s => s.service == service_name).map((table) => (
-            <Table
-              current_time={props.current_time}
-              key={table.position}
-              refresh={props.refresh}
-              service={service_name}
-              {...table}
-            />
-          ))}
-        </Tables>
-      </Service>
-    ))}
-  </Layout>
-)
+    this.timer = null
+
+    this.state = { current_time: moment() }
+  }
+
+  componentDidMount() {
+    this.timer = setInterval(() => this.setTime(), 1000)
+  }
+
+  setTime() {
+    this.setState({ current_time: moment() })
+  }
+
+  componentWillUnmount() {
+    clearInterval(this.timer)
+  }
+
+  render() {
+    return (
+      <Layout position={this.props.position}>
+        { Object.keys(service_directory).map((service_name) => (
+          <Service key={service_name}>
+            <Emoji>{ service_directory[service_name] }</Emoji>
+
+            <Tables>
+              {this.props.services.filter(s => s.service == service_name).map((table) => (
+                <Table
+                  current_time={this.state.current_time}
+                  key={table.position}
+                  refresh={this.props.refresh}
+                  service={service_name}
+                  {...table}
+                />
+              ))}
+            </Tables>
+          </Service>
+        ))}
+      </Layout>
+    )
+  }
+}
 
 const Layout = styled.div`
   ${(p) => p.position};

--- a/app/javascript/components/Order.js
+++ b/app/javascript/components/Order.js
@@ -95,7 +95,7 @@ class Order extends React.Component {
 
     let new_time = moment(chosen_time, "HH:mm")
 
-    const current_hour = this.props.current_time.get("hour")
+    const current_hour = moment().get("hour")
     const chosen_hour = new_time.get("hour")
 
     if(current_hour < 12 && chosen_hour > 12)


### PR DESCRIPTION
The one-second state update on `App`
was causing the `Order` component to re-render.

Moving the one-second updates to `Lobby` fixes the issue.

Fixes #44.