### PR TITLE
Close out orders when employee hits "Confirm"

### DIFF
--- a/app/controllers/update_controller.rb
+++ b/app/controllers/update_controller.rb
@@ -9,11 +9,11 @@ class UpdateController < ApplicationController
 
     order = service.current_order || Order.create!(service: service)
 
-    result = order.update(
+    result = order.update!(
       params.require(:state).permit(:start_time, :end_time, :cash_handled)
     )
 
-    render json: { persisted: result }
+    render json: { persisted: result, closed: !order.open? }
   end
 
   def order_extra
@@ -29,7 +29,7 @@ class UpdateController < ApplicationController
       OrderExtra.find_by(order: order, extra: extra) ||
       OrderExtra.create!(order: order, extra: extra)
 
-    result = order_extra.update(
+    result = order_extra.update!(
       params.require(:state).permit(:quantity)
     )
 

--- a/app/javascript/components/Checkout.js
+++ b/app/javascript/components/Checkout.js
@@ -1,6 +1,5 @@
 import React from "react"
 import styled from "styled-components"
-import { Link } from "react-router-dom"
 import moment from "moment"
 import jquery from "jquery"
 
@@ -61,23 +60,9 @@ class Checkout extends React.Component {
           />
         </Register>
 
-        <Confirm to="/" onClick={this.persist}>Confirm</Confirm>
+        <Confirm onClick={() => this.props.persist(this.state)}>Confirm</Confirm>
       </Layout>
     )
-  }
-
-  persist() {
-    let state = this.state
-    let params = this.props.params
-
-    this.setState({ ...state, persisted: false })
-
-    jquery.ajax({
-      url: "/update/order",
-      type: "PUT",
-      data: { params, state },
-      success: (response) => this.setState({ persisted: response.persisted }),
-    })
   }
 }
 
@@ -94,7 +79,7 @@ const Register = styled.div`
   justify-content: space-between;
 `
 
-const Confirm = styled(Link)`
+const Confirm = styled.span`
   font-size: 1.2rem;
   margin-top: 2rem;
   text-align: center;

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -10,6 +10,10 @@ class Order < ApplicationRecord
     where(end_time: nil).or(where(cash_handled: nil))
   end
 
+  def open?
+    start_time.nil? || end_time.nil? || cash_handled.nil?
+  end
+
   def as_json
     {
       cash_handled: cash_handled,
@@ -17,13 +21,5 @@ class Order < ApplicationRecord
       extras: order_extras.map(&:as_json),
       start_time: start_time,
     }
-  end
-
-  def end_time
-    super
-  end
-
-  def hours_spent
-    ((end_time || Time.current) - start_time) / 3600.to_f
   end
 end


### PR DESCRIPTION
This introduces a bug
where if an employee fills out `cash_handled` and clicks "Confirm"
before setting an end time,
nothing will happen.

Then, when the employee taps the "End Time" field,
the order will immediately close with the current time stored as the end
time.

This bug will be fixed up with a planned feature, #34.
That feature ensures that the end time is always set
before the employee can close the order.

Closes #40.