### PR TITLE
Keep extra quantities synchronized between tabs

### DIFF
--- a/app/javascript/components/Extra.js
+++ b/app/javascript/components/Extra.js
@@ -50,7 +50,10 @@ class Extra extends React.Component {
       url: "/update/order_extra",
       type: "PUT",
       data: { params, state },
-      success: (response) => this.setState({ persisted: response.persisted }),
+      success: (response) => {
+        this.props.refresh()
+        this.setState({ persisted: response.persisted })
+      },
     })
   }
 }

--- a/app/javascript/components/Extras.js
+++ b/app/javascript/components/Extras.js
@@ -10,6 +10,7 @@ const Extras = (props) => (
         key={item.name}
         order={props.order}
         params={props.params}
+        refresh={props.refresh}
         {...item}
       />
     ))}

--- a/app/javascript/components/Order.js
+++ b/app/javascript/components/Order.js
@@ -63,18 +63,21 @@ class Order extends React.Component {
                               items={this.props.state.extras.filter(s => s.extra_type == "snack")}
                               order={this.order}
                               params={this.props.params}
+                              refresh={this.props.refresh}
                             />,
               drinks: () => <Extras
                               extras={this.order.extras}
                               items={this.props.state.extras.filter(s => s.extra_type == "drink")}
                               order={this.order}
                               params={this.props.params}
+                              refresh={this.props.refresh}
                             />,
               other: () => <Extras
                               extras={this.order.extras}
                               items={this.props.state.extras.filter(s => s.extra_type == "other")}
                               order={this.order}
                               params={this.props.params}
+                              refresh={this.props.refresh}
                             />,
               checkout: () => <Checkout
                               extras={this.order.extras}


### PR DESCRIPTION
Closes #51.

There's a side-effect of this change,
where chaanging a quantity on the "Drinks" or "Other" tab
switches the `TabView` back to the "Snacks" tab.

This will be fixed by #31.