### PR TITLE
Persist scroll state after modifying an order

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "eject": "react-app-rewired eject"
   },
   "devDependencies": {
-    "mobx-react-devtools": "^5.0.1",
     "react-app-rewired": "^1.5.2"
   }
 }

--- a/src/App.js
+++ b/src/App.js
@@ -91,10 +91,10 @@ class App extends React.Component {
                       params={match.params}
                       match={match}
                       extras={this.extras}
-                      order={this.services.filter(s =>
+                      order={(this.services.filter(s =>
                           s.service === match.params.service &&
                           s.position === parseInt(match.params.number, 10)
-                        )[0].current_order
+                        )[0] || {current_order: null}).current_order
                       }
                       onCancel={this.cancelOrder}
                       onPersist={(state) => this.persistOrder(state, match.params)}

--- a/src/App.js
+++ b/src/App.js
@@ -41,7 +41,11 @@ class App extends React.Component {
         this.reservations = result.reservations.map(parseReservation)
         this.extras = result.extras.map(parseExtra)
         this.room_pricing_factor = result.room_pricing_factor
-      });
+      })
+      .then(() => {
+        document.querySelector(".orderLayout").scroll(0, window.assemble.scroll)
+        window.assemble.scroll = 0;
+      })
     })
   }
 

--- a/src/App.js
+++ b/src/App.js
@@ -34,13 +34,15 @@ class App extends React.Component {
       reservations: Reservation.all.order(:start_time),
       room_pricing_factor: RoomPricingEvent.order(:created_at).last.try(:pricing_factor) || 100,
     }
-    `((result) => {
-      this.loaded = true
-      this.services = result.services.map(parseService)
-      this.reservations = result.reservations.map(parseReservation)
-      this.extras = result.extras.map(parseExtra)
-      this.room_pricing_factor = result.room_pricing_factor
-    });
+    `((response) => {
+      response.json().then(result => {
+        this.loaded = true
+        this.services = result.services.map(parseService)
+        this.reservations = result.reservations.map(parseReservation)
+        this.extras = result.extras.map(parseExtra)
+        this.room_pricing_factor = result.room_pricing_factor
+      });
+    })
   }
 
   render () {

--- a/src/Assemble.js
+++ b/src/Assemble.js
@@ -1,4 +1,3 @@
-import jquery from "jquery"
 import { runInAction } from "mobx"
 
 class Assemble {
@@ -14,13 +13,13 @@ class Assemble {
         return accumulator + expressions[i - 1] + part
       })
 
-      jquery.ajax({
-        url: "/evaluate",
-        type: "POST",
-        data: { system, code },
-        success: resolve,
-        error: resolve,
-      })
+      fetch("/evaluate", {
+        method: "POST",
+        body: JSON.stringify({ system, code }),
+        headers: {
+          "Content-Type": "application/json",
+        },
+      }).then(resolve)
     }).then((result) => {
       let watches = this.watches[system]
       if(this.active && watches !== undefined) {
@@ -43,13 +42,16 @@ class Assemble {
 
       return (callback) => {
         let watch = () =>
-          jquery.ajax({
-            url: "/evaluate",
-            type: "POST",
-            data: { system, code },
-            success: (result) => { if(this.active) { runInAction(() => callback(result)) } },
-            error: (result) => { if(this.active) { runInAction(() => callback(result)) } },
+          fetch("/evaluate", {
+            method: "POST",
+            body: JSON.stringify({ system, code }),
+            headers: {
+              "Content-Type": "application/json",
+            },
           })
+            .then(result => {
+              if(this.active) { runInAction(() => callback(result)) }
+            })
 
         this.watches[system].push(watch)
         watch()

--- a/src/components/Extra.js
+++ b/src/components/Extra.js
@@ -37,6 +37,9 @@ class Extra extends React.Component {
   add(value) {
     const quantity = this.state.quantity + value
 
+    const layout = document.querySelector(".orderLayout")
+    window.assemble.scroll = layout.scrollTop
+
     this.props.onPersist({ quantity: quantity }, this.props.name)
   }
 }

--- a/src/components/Order.js
+++ b/src/components/Order.js
@@ -33,7 +33,7 @@ class Order extends React.Component {
     return (
       this.props.order == null
       ? <Loading />
-      : <Layout>
+      : <Layout className="orderLayout">
           <Links>
             <StyledLink
               to="/"

--- a/src/index.js
+++ b/src/index.js
@@ -4,5 +4,6 @@ import './index.css';
 import App from './App';
 import registerServiceWorker from './registerServiceWorker';
 
+window.assemble = {}
 ReactDOM.render(<App />, document.getElementById('root'));
 registerServiceWorker();

--- a/yarn.lock
+++ b/yarn.lock
@@ -4569,10 +4569,6 @@ mkdirp@0.5.1, mkdirp@0.5.x, mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0, mkdirp@
   dependencies:
     minimist "0.0.8"
 
-mobx-react-devtools@^5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/mobx-react-devtools/-/mobx-react-devtools-5.0.1.tgz#9473c85929b2fc0c95086430419028cebd96fb3b"
-
 mobx-react@^5.2.3:
   version "5.2.3"
   resolved "https://registry.yarnpkg.com/mobx-react/-/mobx-react-5.2.3.tgz#cdf6141c2fe63377c5813cbd254e8ce0d4676631"


### PR DESCRIPTION
Closes #90.

Upon changing an extra quantity, the order layout's scroll height is
stored as a property on window.assemble.
    
Whenever the page loads data,
it re-scrolls by the stored amount.
