### PR TITLE
Prevent copy/paste dialog on timepicker focus

### DIFF
--- a/src/components/Timepicker.js
+++ b/src/components/Timepicker.js
@@ -46,6 +46,7 @@ class Timepicker extends React.Component {
           onChange={(e) => this.enteredText = e.target.value }
           onFocus={(e) => this.focused(e)}
           onKeyPress={(e) => e.key === "Enter" && this.enter(e)}
+          onSelect={(e) => e.target.selectionStart = e.target.selectionEnd }
           placeholder="--:--"
           value={this.enteredText}
         />


### PR DESCRIPTION

Based on the suggestions posted at:
https://stackoverflow.com/questions/29221991/prevent-select-on-input-text-field

This solution is untested so far as the copy/paste dialog showing up,
since I'm developing on a non-touchscreen.

![no-copy-dialog](https://user-images.githubusercontent.com/30454698/57661425-a3363780-759f-11e9-9f12-933fc8872c14.gif)

